### PR TITLE
Fix Slack notifications by calling gha-slack directly

### DIFF
--- a/.github/workflows/terraform-main.yml
+++ b/.github/workflows/terraform-main.yml
@@ -6,10 +6,26 @@ on:
 
 jobs:
   post-to-slack:
-    uses: entur/dataanalyse-workflows/.github/workflows/dataform-push-to-main.yml@v1
-    with:
-      skip_terraform: true
+    uses: entur/gha-slack/.github/workflows/post.yml@v3
     secrets: inherit
+    with:
+      channel_id: "C08R095NTG8"
+      message: |
+        ✅ *Push to main completed in* 📦 <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>
+        👤 *Author:* ${{ github.event.head_commit.author.name }}
+  post-failure-to-slack:
+    if: failure()
+    needs: [terraform]
+    uses: entur/gha-slack/.github/workflows/post.yml@v3
+    secrets: inherit
+    with:
+      channel_id: "C05ERL9N22V"
+      message: |
+        🚨 *Workflow failed in* 📦 <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>
+        *Branch:* `${{ github.ref_name }}`
+        *Commit:* <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ github.event.head_commit.message }}>
+        *Author:* ${{ github.event.head_commit.author.name }}
+        *Run:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>
   terraform:
     name: "Terraform Validation"
     runs-on: ubuntu-latest

--- a/.github/workflows/terraform-pr.yml
+++ b/.github/workflows/terraform-pr.yml
@@ -6,10 +6,14 @@ on:
 
 jobs:
   post-to-slack:
-    uses: entur/dataanalyse-workflows/.github/workflows/dataform-pr.yml@v1
-    with:
-      skip_terraform: true
+    if: github.event.action == 'opened'
+    uses: entur/gha-slack/.github/workflows/post.yml@v3
     secrets: inherit
+    with:
+      channel_id: "C08R095NTG8"
+      message: |
+        🔄 *New PR in* 📦 *${{ github.repository }}:* <${{ github.event.pull_request.html_url }}|${{ github.event.pull_request.title }}>
+        ✍️ *Author:* ${{ github.event.pull_request.user.login }}
   terraform:
     name: "Terraform"
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- GitHub blocks public repos from calling reusable workflows in internal repos
- Replaces `entur/dataanalyse-workflows/.github/workflows/dataform-pr.yml@v1` and `dataform-push-to-main.yml@v1` with direct calls to `entur/gha-slack/.github/workflows/post.yml@v3` (public)
- Adds a `post-failure-to-slack` job to the main branch workflow to notify on terraform validation failures

## Type of change

Bug fix — workflows were silently broken for this public repo.

## Testing

- Workflow syntax is valid YAML with no structural changes to the `terraform` jobs
- Slack message format matches what the internal workflows previously produced