### PR TITLE
feat(iam)!: grant dataEditor only to custom SA when service_account_email is set

### DIFF
--- a/modules/dataform/iam.tf
+++ b/modules/dataform/iam.tf
@@ -11,7 +11,6 @@ resource "google_bigquery_dataset_iam_binding" "dataform_sa_bigquery_access" {
   dataset_id = each.value.dataset_id
   role       = "roles/bigquery.dataEditor"
   members = var.service_account_email != null ? [
-    local.dataform_service_account,
     "serviceAccount:${var.service_account_email}",
   ] : [local.dataform_service_account]
   project = local.project_id


### PR DESCRIPTION
## Summary
- Drops the default Dataform service agent from the dataset-level `dataEditor` binding when `service_account_email` is set.
- When `service_account_email` is null, behavior is unchanged.

## Breaking change
Consumers that bump to this version while still running workflows as the default Dataform agent will lose `dataEditor` on module-managed datasets. The SA cutover (set `service_account_email`) must already be effective before upgrading.

## Test plan
- [ ] Apply against a consumer already running as the custom SA and confirm the `dataEditor` binding `members` shrinks to just the custom SA, workflows still succeed.
- [ ] Confirm a consumer with `service_account_email = null` shows no diff.